### PR TITLE
fixed case where adjmatrix can have a zero row-vector

### DIFF
--- a/graph-generator/generator.hpp
+++ b/graph-generator/generator.hpp
@@ -35,30 +35,25 @@ Graph::Graph(int numNodes, int seed) : uniform(1, 100), cost(-120, 100) {
       this->adjMatrix[j][i] = adjMatrix[i][j] = getRandCost();
     }
   }
-
+	
   for (int i = 0; i < numNodes; i++) {
     int max = -1337;
     int maxIndex = -1337;
     for (int j = 0; j < numNodes; j++) {
-      if (this->adjMatrix[i][j] > max) {
+      if (this->adjMatrix[i][j] > max and i !=j ) {
         max = this->adjMatrix[i][j];
         maxIndex = j;
       }
-      if (this->adjMatrix[i][j] <= 0) {
-        this->adjMatrix[i][j] = -1337;
+      if (this->adjMatrix[i][j] <= 0 or i == j) {
+        this->adjMatrix[i][j] = 0;
       }
     }
+
     if (max <= 0) {
       this->adjMatrix[i][maxIndex] = this->getRandUniform();
     }
   }
 
-  for (int i = 0; i < numNodes; i++) {
-    for (int j = 0; j < numNodes; j++) {
-      if (this->adjMatrix[i][j] == -1337 || i == j) {
-        this->adjMatrix[i][j] = 0;
-      }
-    }
-  }
+
 }
 #endif // GENERATOR_H


### PR DESCRIPTION
I didn't (don't) have time to test the changes in depth, but previously I believe there was a case where the max (non-positive) edge was where i==j, which later gets overwritten to 0, resulting in a row of all zeroes.

Solution: maxIndex isn't updated if i==j, so in effect the second-greatest edge becomes replaced with the uniform distribution (1,100). It should now be impossible to generate a matrix with 0-rows.

(Also, I believe the issue only occurs at lower numbers of computers due to the way the statistics work out. You can reproduce the issue quite readily on the original version by generating a graph with 5 nodes a few times in a row.)